### PR TITLE
Allow parameters to be passed to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ This was heavily inspired from: https://grafana.com/dashboards/713
 check here to find a overview of more attributes which probaly could be added
 https://wiki.fhem.de/w/index.php?title=FRITZBOX
 
+To specify service actions that need parameters, you can put it like this:
+
+```
+service = WANCommonInterfaceConfig
+actions = X_AVM-DE_GetOnlineMonitor,NewSyncGroupIndex=0
+```
+
 # License
 >You can check out the full license [here](LICENSE.txt)
 

--- a/fritzinfluxdb.py
+++ b/fritzinfluxdb.py
@@ -134,13 +134,17 @@ def query_services(fc, services):
         """
 
         call_result = None
-        logging.debug(f"Requesting {service_called} : {action_called}")
+        actions = action_called.split(',')
+        parameters = {s.split('=')[0]: s.split('=')[1] for s in actions[1:]}
+        action = actions[0]
+
+        logging.debug(f"Requesting {service_called} : {action} ({parameters})")
         try:
-            call_result = fc.call_action(service_called, action_called)
+            call_result = fc.call_action(service_called, action, **parameters)
         except fritzconnection.core.exceptions.FritzServiceError:
             logging.error(f"Requested invalid service: {service_called}")
         except fritzconnection.core.exceptions.FritzActionError:
-            logging.error(f"Requested invalid action '{action_called}' for service: {service_called}")
+            logging.error(f"Requested invalid action '{action}' for service: {service_called}")
 
         if call_result is not None:
             logging.debug("Request returned successfully")


### PR DESCRIPTION
I wanted to try out the `X_AVM-DE_GetOnlineMonitor` action, which needs a parameter to be passed, so this MR implements static parameters to be passed to actions in the most easy way :-)

It disallows `,` to be used as action name and `=` to be used as parameter name or value. So far, this seems acceptable...

I don't know if this functionality is useful for anybody, @bb-Ricardo maybe you want to decide if this should be merged?